### PR TITLE
Fix dns response codes

### DIFF
--- a/pkt/src/dns.rs
+++ b/pkt/src/dns.rs
@@ -8,15 +8,16 @@ pub mod opcode {
 
 pub mod rcode {
     pub const NOERROR: u8 = 0;
-    pub const FORMERROR: u8 = 1;
+    pub const FORMERR: u8 = 1;
     pub const SERVFAIL: u8 = 2;
     pub const NXDOMAIN: u8 = 3;
     pub const NOTIMP: u8 = 4;
     pub const REFUSED: u8 = 5;
     pub const YXDOMAIN: u8 = 6;
-    pub const XRRSET: u8 = 7;
-    pub const NOTAUTH: u8 = 8;
-    pub const NOTZONE: u8 = 9;
+    pub const YXRRSET: u8 = 7;
+    pub const NXRRSET: u8 = 8;
+    pub const NOTAUTH: u8 = 9;
+    pub const NOTZONE: u8 = 10;
 }
 
 pub mod flags {

--- a/src/stdlib/dns.rs
+++ b/src/stdlib/dns.rs
@@ -20,6 +20,20 @@ const OPCODE: phf::Map<&'static str, Symbol> = phf_map! {
     "STATUS" => Symbol::u8(opcode::STATUS),
 };
 
+const RCODE: phf::Map<&'static str, Symbol> = phf_map! {
+    "NOERROR" => Symbol::u8(rcode::NOERROR),
+    "FORMERR" => Symbol::u8(rcode::FORMERR),
+    "SERVFAIL" => Symbol::u8(rcode::SERVFAIL),
+    "NXDOMAIN" => Symbol::u8(rcode::NXDOMAIN),
+    "NOTIMP" => Symbol::u8(rcode::NOTIMP),
+    "REFUSED" => Symbol::u8(rcode::REFUSED),
+    "YXDOMAIN" => Symbol::u8(rcode::YXDOMAIN),
+    "YXRRSET" => Symbol::u8(rcode::YXRRSET),
+    "NXRRSET" => Symbol::u8(rcode::NXRRSET),
+    "NOTAUTH" => Symbol::u8(rcode::NOTAUTH),
+    "NOTZONE" => Symbol::u8(rcode::NOTZONE),
+};
+
 const TYPE: phf::Map<&'static str, Symbol> = phf_map! {
     "A" => Symbol::u16(rrtype::A),
     "NS" => Symbol::u16(rrtype::NS),
@@ -294,6 +308,7 @@ const DNS_HOST: FuncDef = func_def!(
 
 pub const DNS: phf::Map<&'static str, Symbol> = phf_map! {
     "opcode" => Symbol::Module(&OPCODE),
+    "rcode" => Symbol::Module(&RCODE),
     "type" => Symbol::Module(&TYPE),
     "class" => Symbol::Module(&CLASS),
     "flags" => Symbol::Func(&DNS_FLAGS),


### PR DESCRIPTION
- Add rcode to stdlib dns exports
- Rename 'FORMERROR' const to 'FORMERR'
- Split 'XRRSET' into 'YXRRSET' and 'NXRRSET'
- Fix dns rcode values