### PR TITLE
Add --output flag to cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ lazy-regex = "2.2.2"
 regex = "1.5.4"
 phf = { version = "0.10.1", features = ["macros"] }
 
-clap = {version = "3.0.0", optional = true}
+clap = {version = "3.2.14", optional = true}
 atty = {version = "0.2.14", optional = true}
 termcolor = {version = "1.1.2", optional = true}
 


### PR DESCRIPTION
This commit provides an alternative output option to specify output
filenames. Original --out-dir option still works as expected but no longer
has short -o flag. Also replaced some deprecated clap function calls.