### PR TITLE
Feature/consecutive string literal concatenation support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,7 +78,7 @@ pub fn process_file(stdout: &mut StandardStream,
         };
 
         for tok in toks {
-            if let Err(err) = parse.feed(tok) {
+            if let Err(err) = parse.feed(&tok) {
                 return Err(ErrorLoc::new(tok.loc(), err));
             }
         }
@@ -88,7 +88,7 @@ pub fn process_file(stdout: &mut StandardStream,
         }
     }
 
-    if let Err(err) = parse.feed(EOF) {
+    if let Err(err) = parse.feed(&EOF) {
         return Err(ErrorLoc::new(lex.loc(), err));
     }
 

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -163,7 +163,7 @@ impl TokType {
 /// ## Lifetime
 /// For things like identifiers and string literals, a reference is included to the original
 /// string. So the [Token] must outlive that buffer.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Token<'a> {
     loc: Loc,
     typ: TokType,
@@ -188,8 +188,8 @@ impl<'a> Token<'a> {
     }
 }
 
-impl From<Token<'_>> for String {
-    fn from(tok: Token) -> String {
+impl From<&Token<'_>> for String {
+    fn from(tok: &Token) -> String {
         tok.val.unwrap().to_owned()
     }
 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -148,12 +148,12 @@ impl TokType {
 
     pub fn get_val(self, val: &str) -> Option<&str> {
         match self {
-        TokType::Identifier => Some(val),
-        TokType::HexIntegerLiteral => Some(val),
-        TokType::IntegerLiteral => Some(val),
-        TokType::BooleanLiteral => Some(val),
-        TokType::StringLiteral => Some(&val[1..val.len()-1]),
-        TokType::IPv4Literal => Some(val),
+            TokType::Identifier => Some(val),
+            TokType::HexIntegerLiteral => Some(val),
+            TokType::IntegerLiteral => Some(val),
+            TokType::BooleanLiteral => Some(val),
+            TokType::StringLiteral => Some(&val[1..val.len()-1]),
+            TokType::IPv4Literal => Some(val),
         _ => None,
         }
     }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::slice::Iter;
 
 use lazy_regex::*;
@@ -167,7 +168,7 @@ impl TokType {
 pub struct Token<'a> {
     loc: Loc,
     typ: TokType,
-    val: Option<&'a str>,
+    val: Option<Cow<'a, str>>,
 }
 
 impl<'a> Token<'a> {
@@ -179,18 +180,18 @@ impl<'a> Token<'a> {
         self.typ
     }
 
-    pub fn optval(&self) -> Option<&'a str> {
-        self.val
+    pub fn optval(&self) -> Option<Cow<'a, str>> {
+        self.val.to_owned()
     }
 
-    pub fn val(&self) -> &'a str {
-        self.val.unwrap()
+    pub fn val(&self) -> Cow<'a, str> {
+        self.val.as_ref().unwrap().to_owned()
     }
 }
 
 impl From<&Token<'_>> for String {
     fn from(tok: &Token) -> String {
-        tok.val.unwrap().to_owned()
+        tok.val.as_ref().unwrap().to_string()
     }
 }
 
@@ -259,7 +260,7 @@ impl Lexer {
                 ret.push(Token {
                     loc: Loc::new(lno, pos + 1),
                     typ: tok_type,
-                    val: tok_type.get_val(tok_val),
+                    val: tok_type.get_val(tok_val).map(Cow::from),
                 });
             }
 

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -151,7 +151,7 @@ impl TokType {
         TokType::HexIntegerLiteral => Some(val),
         TokType::IntegerLiteral => Some(val),
         TokType::BooleanLiteral => Some(val),
-        TokType::StringLiteral => Some(val),
+        TokType::StringLiteral => Some(&val[1..val.len()-1]),
         TokType::IPv4Literal => Some(val),
         _ => None,
         }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -208,6 +208,7 @@ pub const EOF: Token = Token {
 #[derive(Debug, Default)]
 pub struct Lexer {
     loc: Loc,
+    concatenated_strings: String,
 }
 
 impl Lexer {
@@ -223,8 +224,12 @@ impl Lexer {
     pub fn line<'a>(&mut self, lno: usize, line: &'a str) -> Result<Vec<Token<'a>>, Error> {
         let mut ret = Vec::new();
         let mut pos = 0_usize;
-        let mut string_literals = Vec::new();
+        let mut string_literals: Vec<&str> = Vec::new();
         let mut caps = LEX_RE.capture_locations();
+
+        if !self.concatenated_strings.is_empty() {
+            string_literals.push(&self.concatenated_strings);
+        }
 
         self.loc = Loc::new(lno, pos + 1);
 
@@ -279,6 +284,12 @@ impl Lexer {
 
             pos += m.end();
         }
+
+        self.concatenated_strings = if string_literals.is_empty() {
+            String::new()
+        } else {
+            string_literals.concat()
+        };
 
         self.loc = Loc::new(lno, pos + 1);
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -491,7 +491,7 @@ impl Parser {
         self.stmts.push(stmt.into());
     }
 
-    fn state_initial(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_initial(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::ImportKeyword => Ok(Action::Discard(State::Import)),
             TokType::LetKeyword => Ok(Action::Discard(State::Let)),
@@ -501,7 +501,7 @@ impl Parser {
         }
     }
 
-    fn state_import(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_import(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Identifier => {
                 self.push(Node::Loc(tok.loc()));
@@ -511,19 +511,19 @@ impl Parser {
         }
     }
 
-    fn state_import_end(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_import_end(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::SemiColon => Ok(Action::Discard(State::ReduceImport)),
             _ => Err(ParseError)
         }
     }
 
-    fn state_reduce_import(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_import(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_import_stmt();
         Ok(Action::Goto(State::ReduceStmt))
     }
 
-    fn state_let(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_let(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Identifier => {
                 self.push(Node::Loc(tok.loc()));
@@ -533,14 +533,14 @@ impl Parser {
         }
     }
 
-    fn state_assign(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_assign(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Equals => Ok(Action::Discard(State::ExprRvalue)),
             _ => Err(ParseError)
         }
     }
 
-    fn state_ref_component(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_ref_component(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::DoubleColon => Ok(Action::Discard(State::ReduceModule)),
             TokType::Dot => Ok(Action::Discard(State::ReduceObject)),
@@ -549,28 +549,28 @@ impl Parser {
         }
     }
 
-    fn state_reduce_object(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_object(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_object();
         Ok(Action::Goto(State::RefObject))
     }
 
-    fn state_reduce_ref_call(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_ref_call(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_ref();
         self.push(Node::ArgList(Vec::new()));
         Ok(Action::Goto(State::ExprArg))
     }
 
-    fn state_reduce_ref_naked(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_ref_naked(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_ref();
         Ok(Action::Goto(State::ReduceRefExpr))
     }
 
-    fn state_reduce_module(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_module(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_module();
         Ok(Action::Goto(State::RefModule))
     }
 
-    fn state_ref_module(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_ref_module(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Identifier => Ok(
                 Action::Shift(State::RefComponent, Node::Component(tok.into()))
@@ -579,7 +579,7 @@ impl Parser {
         }
     }
 
-    fn state_ref_object(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_ref_object(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Identifier => Ok(
                 Action::Shift(State::RefObjEnd, Node::Component(tok.into())),
@@ -588,7 +588,7 @@ impl Parser {
         }
     }
 
-    fn state_ref_obj_end(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_ref_obj_end(&mut self, tok: &Token) -> Result<Action, Error> {
         Ok(match tok.tok_type() {
             TokType::Dot => Action::Discard(State::ReduceObject),
             TokType::LParen => Action::Discard(State::ReduceRefCall),
@@ -596,7 +596,7 @@ impl Parser {
         })
     }
 
-    fn state_arg_next(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_arg_next(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Comma => Ok(Action::Discard(State::ExprArg)),
             TokType::RParen => Ok(Action::Shift(State::ReduceCall, Node::State(State::ReduceArg))),
@@ -605,7 +605,7 @@ impl Parser {
     }
 
     #[inline(always)]
-    fn push_literal(&mut self, tok: Token) -> Result<Action, Error> {
+    fn push_literal(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::StringLiteral
             | TokType::BooleanLiteral
@@ -622,7 +622,7 @@ impl Parser {
         }
     }
 
-    fn state_expr_arg(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_expr_arg(&mut self, tok: &Token) -> Result<Action, Error> {
         Ok(match tok.tok_type() {
             TokType::Identifier => Action::Shift(State::ArgName, Node::ArgName(Some(tok.into()))),
             _ => {
@@ -632,7 +632,7 @@ impl Parser {
         })
     }
 
-    fn state_arg_name(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_arg_name(&mut self, tok: &Token) -> Result<Action, Error> {
         Ok(match tok.tok_type() {
             TokType::Colon => Action::Discard(State::ArgVal),
             _ => {
@@ -646,7 +646,7 @@ impl Parser {
         })
     }
 
-    fn state_arg_val(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_arg_val(&mut self, tok: &Token) -> Result<Action, Error> {
         self.push_goto(State::ReduceArg);
         match tok.tok_type() {
             TokType::Identifier => {
@@ -668,12 +668,12 @@ impl Parser {
         }
     }
 
-    fn state_expr_stmt(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_expr_stmt(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.push_goto(State::ExprStmtEnd);
         Ok(Action::Goto(State::Expr))
     }
 
-    fn state_expr(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_expr(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::Identifier => {
                 self.push(Node::Path(PathBuilder::new(tok.loc())));
@@ -688,19 +688,19 @@ impl Parser {
         }
     }
 
-    fn state_expr_rvalue(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_expr_rvalue(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.push_goto(State::AssignStmtEnd);
         Ok(Action::Goto(State::Expr))
     }
 
-    fn state_ipv4(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_ipv4(&mut self, tok: &Token) -> Result<Action, Error> {
         Ok(match tok.tok_type() {
             TokType::Colon => Action::Discard(State::IPv4Colon),
             _ => Action::Goto(State::ReduceLiteralExpr)
         })
     }
 
-    fn state_ipv4_colon(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_ipv4_colon(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::IntegerLiteral => {
                 self.push(Node::Loc(tok.loc()));
@@ -710,27 +710,27 @@ impl Parser {
         }
     }
 
-    fn state_reduce_arg(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_arg(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_arg();
         Ok(Action::Goto(State::ArgNext))
     }
 
-    fn state_reduce_literal_expr(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_literal_expr(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_literal_expr();
         Ok(Action::Goto(State::Slash))
     }
 
-    fn state_reduce_ref_expr(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_ref_expr(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_ref_expr();
         Ok(Action::Goto(State::Slash))
     }
 
-    fn state_reduce_call_expr(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_call_expr(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_call_expr();
         Ok(Action::Goto(State::Slash))
     }
 
-    fn state_slash(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_slash(&mut self, tok: &Token) -> Result<Action, Error> {
         Ok(match tok.tok_type() {
             TokType::Slash => {
                 self.push(Node::Slash);
@@ -741,64 +741,64 @@ impl Parser {
         })
     }
 
-    fn state_reduce_expr(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_expr(&mut self, _tok: &Token) -> Result<Action, Error> {
         let expr = self.pop();
         let st = self.pop();
         self.push(expr);
         Ok(Action::Goto(st.into()))
     }
 
-    fn state_reduce_sockaddr(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_sockaddr(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_sockaddr();
         Ok(Action::Goto(State::ReduceLiteralExpr))
     }
 
-    fn state_reduce_call(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_call(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.pop(); // state for next arg
         self.reduce_call();
         Ok(Action::Goto(State::ReduceCallExpr))
     }
 
-    fn state_expr_stmt_end(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_expr_stmt_end(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::SemiColon => Ok(Action::Discard(State::ReduceExprStmt)),
             _ => Err(ParseError)
         }
     }
 
-    fn state_assign_stmt_end(&mut self, tok: Token) -> Result<Action, Error> {
+    fn state_assign_stmt_end(&mut self, tok: &Token) -> Result<Action, Error> {
         match tok.tok_type() {
             TokType::SemiColon => Ok(Action::Discard(State::ReduceAssign)),
             _ => Err(ParseError)
         }
     }
 
-    fn state_reduce_bop(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_bop(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_bop_expr();
         Ok(Action::Goto(State::ReduceExpr))
     }
 
-    fn state_reduce_assign(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_assign(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_assign();
         Ok(Action::Goto(State::ReduceAssignStmt))
     }
 
-    fn state_reduce_expr_stmt(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_expr_stmt(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_expr_stmt();
         Ok(Action::Goto(State::ReduceStmt))
     }
 
-    fn state_reduce_assign_stmt(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_assign_stmt(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_assign_stmt();
         Ok(Action::Goto(State::ReduceStmt))
     }
 
-    fn state_reduce_stmt(&mut self, _tok: Token) -> Result<Action, Error> {
+    fn state_reduce_stmt(&mut self, _tok: &Token) -> Result<Action, Error> {
         self.reduce_stmt();
         Ok(Action::Goto(State::Initial))
     }
 
-    fn dispatch(&mut self, tok: Token) -> Result<Action, Error> {
+    fn dispatch(&mut self, tok: &Token) -> Result<Action, Error> {
         //println!("{:<24} {:?} {:?}", format!("State::{:?}", self.state), tok.tok_type(), tok.optval());
         match self.state {
             State::Initial => self.state_initial(tok),
@@ -855,7 +855,7 @@ impl Parser {
         }
     }
 
-    pub fn feed(&mut self, tok: Token) -> Result<(), Error> {
+    pub fn feed(&mut self, tok: &Token) -> Result<(), Error> {
         loop {
             let action = self.dispatch(tok)?;
             match action {

--- a/src/str.rs
+++ b/src/str.rs
@@ -76,13 +76,12 @@ fn hex_decode(chr: char) -> u8 {
 impl FromStr for Buf {
     type Err = StringLiteralParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let inner = &s[1..s.len() - 1];
         let mut hex = false;
         let mut v: Vec<u8> = Vec::new();
         let mut h: [u8; 2] = [0, 0];
         let mut ix: usize = 0;
 
-        for chr in inner.chars() {
+        for chr in s.chars() {
             if !hex {
                 if chr == '|' {
                     hex = true;

--- a/src/val.rs
+++ b/src/val.rs
@@ -476,7 +476,7 @@ impl Typed for Val {
 }
 
 impl Val {
-    pub fn from_token(tok: Token) -> Result<Self, Error> {
+    pub fn from_token(tok: &Token) -> Result<Self, Error> {
         use Val::*;
         use TokType::*;
         let v = tok.val();


### PR DESCRIPTION
Add concatenation of consecutive string literals in a similar manner to that of C.

The following statements are identical after lexing and parsing:

``` rust
let message = "hello" "world";
let message = "hello"
              "world";
let message = "helloworld";
```